### PR TITLE
Init fix for the Ui-toolkit

### DIFF
--- a/workspace/utilities/master/master-toolkit.xsl
+++ b/workspace/utilities/master/master-toolkit.xsl
@@ -18,6 +18,7 @@
 <xsl:import href="css.xsl" />
 
 <!-- LIB -->
+<xsl:import href="../lib/page-title.xsl" />
 <xsl:import href="../lib/master-title.xsl" />
 <xsl:import href="../lib/create-page-url.xsl" />
 <xsl:import href="../lib/date-time.xsl" />


### PR DESCRIPTION
master-tool.xsl was missing a component to work on init
