### PR TITLE
Update on the default font-size mixins

### DIFF
--- a/workspace/assets/css/lib/fonts.less
+++ b/workspace/assets/css/lib/fonts.less
@@ -26,24 +26,3 @@
 	font-weight: @font-weight;
 	font-style: @font-style;
 }
-
-#generate-typo-level(@prefix: '') {
-	
-	//====== HEADINGS ============
-	.heading-@{prefix}xxl { .heading-xxl; }
-	.heading-@{prefix}xl { .heading-xl; }
-	.heading-@{prefix}lg { .heading-lg; }
-	.heading-@{prefix}md { .heading-md; }
-	.heading-@{prefix}sm { .heading-sm; }
-	.heading-@{prefix}xs { .heading-xs; }
-	.heading-@{prefix}xxs { .heading-xxs; }
-
-	//====== TYPO ============
-	.typo-@{prefix}-xxl { .typo-xxl; }
-	.typo-@{prefix}-xl { .typo-xl; }
-	.typo-@{prefix}-lg { .typo-lg; }
-	.typo-@{prefix}-md { .typo-md; }
-	.typo-@{prefix}-sm { .typo-sm; }
-	.typo-@{prefix}-xs { .typo-xs; }
-	.typo-@{prefix}-xxs { .typo-xxs; }
-}

--- a/workspace/assets/css/site/default-style.less
+++ b/workspace/assets/css/site/default-style.less
@@ -22,19 +22,19 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 h1 {
-	.heading-xl;
+	.heading-76;
 }
 
 h2 {
-	.heading-lg;
+	.heading-30;
 }
 
 h3 {
-	.heading-md;
+	.heading-24;
 }
 
 h4, h5, h6 {
-	.heading-sm;
+	.heading-16;
 }
 
 p, .p, li, a {

--- a/workspace/assets/css/site/fonts.less
+++ b/workspace/assets/css/site/fonts.less
@@ -3,69 +3,73 @@
  */
 
 //====== HEADINGS ============
-.heading-xxl {
-	#font-size(15rem, 15.5rem);
+.heading-76 {
+	#font-size(7.6rem, 8rem);
 }
 
-.heading-xl {
-	#font-size(8rem, 9rem);
+.heading-30 {
+	#font-size(3rem, 3.4rem);
 }
 
-.heading-lg {
-	#font-size(3.2rem, 3.8rem);
+.heading-28 {
+	#font-size(2.8rem, 3.2rem);
 }
 
-.heading-md {
-	#font-size(2.4rem, 3rem);
+.heading-26 {
+	#font-size(2.6rem, 3rem);
 }
 
-.heading-sm {
-	#font-size(1.6rem, 2rem);
+.heading-24 {
+	#font-size(2.4rem, 2.8rem);
 }
 
-.heading-xs {
+.heading-22 {
+	#font-size(2.2rem, 2.4rem);
+}
+
+.heading-20 {
+	#font-size(2rem, 2.2rem);
+}
+
+.heading-18 {
+	#font-size(1.8rem, 2rem);
+}
+
+.heading-16 {
+	#font-size(1.6rem, 1.8rem);
+}
+
+.heading-14 {
 	#font-size(1.4rem, 1.6rem);
 }
 
-.heading-xxs {
-	#font-size(1rem, 1.1rem);
+.heading-12 {
+	#font-size(1.2rem, 1.4rem);
 }
 
+.heading-10 {
+	#font-size(10px, 11px);
+}
 
 //====== TYPO ============
-.typo-xxl {
-	#font-size(5rem);
+
+.text-22 {
+	#font-size(2.2rem, 3.6rem);
 }
 
-.typo-xl {
-	#font-size(4rem);
+.text-20 {
+	#font-size(2rem, 3.2rem);
 }
 
-.typo-lg {
-	#font-size(3rem);
+.text-18 {
+	#font-size(1.8rem, 3rem);
 }
 
-.typo-md {
-	#font-size(2.4rem);
+.text-16 {
+	#font-size(1.6rem, 2.8rem);
 }
 
-.typo-sm {
-	#font-size(1.6rem);
+.text-14 {
+	#font-size(1.4rem, 2.6rem);
 }
 
-.typo-xs {
-	#font-size(1.4rem);
-}
-
-.typo-xxs {
-	#font-size(1rem);
-}
-
-//====== RESPONSIVE ============
-#generate-typo-level(~'');
-#mq-min-width(@screen-ph, { #generate-typo-level(ph-); });
-#mq-min-width(@screen-xs, { #generate-typo-level(xs-); });
-#mq-min-width(@screen-sm, { #generate-typo-level(sm-); });
-#mq-min-width(@screen-md, { #generate-typo-level(md-); });
-#mq-min-width(@screen-lg, { #generate-typo-level(lg-); });
-#mq-min-width(@screen-xl, { #generate-typo-level(xl-); });


### PR DESCRIPTION
Replaced the depreciated letter labeled mixings by number label ones.
Delete all the useless code that came with the latter labeled mixins.