### PR TITLE
Seconf fix for sender email in email event

### DIFF
--- a/workspace/events/lib/class.emailevent.php
+++ b/workspace/events/lib/class.emailevent.php
@@ -77,8 +77,8 @@
 
 		private function __sendEmail() {
 			$email = Email::create();
-			$email->setSenderEmailAddress($this->getSenderEmail);
 			$email->setFrom($this->getFromEmail(), $this->getFromName());
+			$email->setSenderEmailAddress($this->getSenderEmail);
 			$email->setReplyToEmailAddress($this->getFromEmail());
 			$email->setRecipients($this->getReceipients());
 			$email->setSubject($this->getSubject());


### PR DESCRIPTION
sender email was overwritten by set from. switched the calls to do setFrom first and then setSender