### PR TITLE
Add two new tasks for filtering src used by csso.

### DIFF
--- a/workspace/assets/Gruntfile.js
+++ b/workspace/assets/Gruntfile.js
@@ -8,11 +8,10 @@ module.exports = function (grunt) {
 	var GRUNT_FILE = 'Gruntfile.js';
 	var BUILD_FILE = 'build.json';
 	var LESS_FILE = 'css/dev/grunt.less';
-
+	var PAGES_PATH = '../pages/*.xsl';
 	var DEV_LIB_BUNDLE_LESS_FILE = 'css/dev/lib.less';
 	var DEV_THEME_BUNDLE_LESS_FILE = 'css/dev/theme.less';
 
-	
 	var JSON_JS_FILE = grunt.file.readJSON('./js.json');
 	
 	var fixJsFilePath = function (f) {
@@ -56,7 +55,7 @@ module.exports = function (grunt) {
 			'<%= pkg.author.name %> (<%= pkg.author.url %>);\n' +
 			' * <%= pkg.license %> */'
 		},
-		
+
 		src: {
 			js: {
 				src: SRC_FILES,
@@ -96,7 +95,21 @@ module.exports = function (grunt) {
 			files: SRC_FILES.concat(GRUNT_FILE),
 			tasks: ['dev', 'css']
 		},
-		
+
+		xsltimportextractor: {
+			options: {
+				pagesPath: PAGES_PATH
+			}
+		},
+
+		cssopruner: {
+			compress: {
+				options: {
+					src: []
+				}
+			}
+		},
+
 		buildnum: {},
 		svninfo: {}
 	};
@@ -154,6 +167,8 @@ module.exports = function (grunt) {
 		grunt.registerTask('css', [
 			'clean:css',
 			'less:production',
+			'xsltimportextractor',
+			'cssoprunerconcatsrc',
 			'cssopruner',
 			'csso'
 		]);

--- a/workspace/assets/package.json
+++ b/workspace/assets/package.json
@@ -34,6 +34,7 @@
     "maxmin": "^2.1.0",
     "request": "^2.79.0",
     "strip-json-comments": "^2.0.1",
-    "time-grunt": "^1.4.0"
+    "time-grunt": "^1.4.0",
+    "libxmljs": "^0.18.2"
   }
 }

--- a/workspace/assets/tasks/cssopruner.js
+++ b/workspace/assets/tasks/cssopruner.js
@@ -32,17 +32,7 @@ module.exports = function cssopruner (grunt) {
 						'hr',
 						/^ui/
 					],
-					blacklist: ['www', 'version', 'xml'],
-					src: [
-						'../pages/*.xsl',
-						'../utilities/*.xsl',
-						'../utilities/**/*.xsl',
-						'js/com/*.js',
-						'js/modules/*.js',
-						'js/pages/*.js',
-						'js/transitions/*.js',
-						'js/utils/*.js'
-					]
+					blacklist: ['www', 'version', 'xml']
 				}
 			}
 		}

--- a/workspace/assets/tasks/cssoprunerconcatsrc.js
+++ b/workspace/assets/tasks/cssoprunerconcatsrc.js
@@ -1,0 +1,27 @@
+'use strict';
+
+module.exports = function cssoprunerconcatsrc (grunt) {
+	grunt.registerTask('cssoprunerconcatsrc', 'DESCRIPTION', function () {
+		var options = this.options();
+		var conf = grunt.config.get();
+		var src = conf.cssopruner.compress.options.src;
+
+		//merge xslt
+		var xsltFiles = grunt.config.get('xsltimportextrator.files.unique');
+
+		xsltFiles.forEach(function (item) {
+			src.push(item.src);
+		});
+
+		var jsSrc = grunt.config.get('src.js.src');
+		jsSrc.forEach(function (item) {
+			src.push(item);
+		});
+
+		src.forEach(function (item) {
+			grunt.log.writeln(item);
+		});
+
+		grunt.config.set('cssopruner.compress.options.src', src);
+	});
+};

--- a/workspace/assets/tasks/xsltimportextractor.js
+++ b/workspace/assets/tasks/xsltimportextractor.js
@@ -1,0 +1,117 @@
+'use strict';
+
+module.exports = function xsltimportextractor (grunt) {
+	// Set default config
+	
+	grunt.registerTask('xsltimportextractor', 'DESCRIPTION', function () {
+		var options = this.options();
+		var libxmljs = require("libxmljs");
+		var pages = grunt.file.expand(options.pagesPath);
+		var files = {};
+		var finalFiles = [];
+		var basePath = '';
+		var level = 0;
+
+		var processPage = function (f) {
+			//Template list
+
+			var processFile = function (f) {
+
+				var oldBasePath = basePath;
+
+				var processImports = function (item) {
+					//Lookup href
+					var href = item.attr('href').value();
+
+					processFile(href);
+				};
+
+				//Append files
+				var lastSlash = f.lastIndexOf("/");
+				
+				if (lastSlash !== -1) {
+					//Check Truncate
+
+					if (basePath.length === 0) {
+						basePath += f.substring(0, lastSlash + 1);
+
+					} else if(f.startsWith("../")) {
+						var countRemove = 0;
+
+						f.split('/').forEach(function (ff) {
+							if (ff == '..') {
+								countRemove += 1;
+							}
+						});
+
+						//Truncate a part
+						var splitedBasePath = basePath.split('/');
+
+						if (splitedBasePath.length > 1) {
+							var newBasePath = '';
+							var x = 1;
+
+							splitedBasePath.forEach(function (item) {
+								if (x == 1) {
+									//always keep first ../
+									newBasePath += item + '/';
+									x += 1;
+								} else if (splitedBasePath.length - x > countRemove) {
+									newBasePath += item + '/';
+									x += 1;
+								}
+							});
+
+							//Fix ../ if not enought
+							while(x < countRemove) {
+								newBasePath += '../';
+								x +=1;
+							}
+							basePath = newBasePath + f.substring(countRemove * 3, lastSlash + 1);
+						}
+					} else {
+						//Append
+						basePath += f.substring(0, lastSlash + 1);
+					}
+
+				} //else {
+					//Do nothing
+				//}
+
+				var fixedFilePath = basePath + f.substring(lastSlash + 1);
+
+				if (!!!files[fixedFilePath] && fixedFilePath.indexOf('ui-toolkit') === -1) {
+					files[fixedFilePath] = fixedFilePath;
+					level += 1;
+
+					finalFiles.push({src:fixedFilePath, level: level});
+
+					var xml = grunt.file.read(fixedFilePath);
+
+					var xmlDoc = libxmljs.parseXmlString(xml);
+					var imports = xmlDoc.find('//xsl:import', {xsl: 'http://www.w3.org/1999/XSL/Transform'})
+
+					if (imports) {
+						imports.forEach(processImports);
+					}
+					level -= 1;
+				}
+				basePath = oldBasePath;
+			};
+			processFile(f);
+		};
+
+		pages.forEach(processPage);
+
+		//Print
+		finalFiles.forEach(function (item) {
+			grunt.log.write('(' + item.level + ') ');
+			for (var i = 0; i < item.level; i++) {
+				grunt.log.write('  ');
+			}
+			grunt.log.writeln(item.src);
+		});
+		
+		grunt.config.set('xsltimportextrator.files.unique', finalFiles);
+	});
+};


### PR DESCRIPTION
1. xslt import extractor: Output all xslt file used by symphony for all the page.
2. csso pruner concat src: merge js files and xslt import extrator files in the array used by csso pruner.