### PR TITLE
New image template

### DIFF
--- a/workspace/utilities/lib/image.xsl
+++ b/workspace/utilities/lib/image.xsl
@@ -1,33 +1,58 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" 
-								xmlns:exsl="http://exslt.org/common" 
-								extension-element-prefixes="exsl">
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+	xmlns:exsl="http://exslt.org/common"
+	xmlns:util="https://github.com/DeuxHuitHuit/288-utils"
+	extension-element-prefixes="exsl util">
 
 	<xsl:variable name="default-image-sizes">
 		<sizes>
-			<size height="0" width="430" />
-			<size height="0" width="620" />
-			<size height="0" width="800" />
-			<size height="0" width="960" />
-			<size height="0" width="1100" />
-			<size height="0" width="1260" />
-			<size height="0" width="1400" />
-			<size height="0" width="2000" />
+			<size height="0" width="430" media="(max-width: 430px)" />
+ 			<size height="0" width="620" media="(max-width: 620px)" />
+ 			<size height="0" width="760" media="(max-width: 760px)" />
+ 			<size height="0" width="890" media="(max-width: 890px)" />
+ 			<size height="0" width="1120" media="(max-width: 1120px)" />
+ 			<size height="0" width="1260" media="(max-width: 1260px)" />
+ 			<size height="0" width="1560" media="(max-width: 1560px)" />
+ 			<size height="0" width="1920" media="(max-width: 1920px)" />
+			<size height="0" width="2500" media="(max-width: 2500px)" />
 		</sizes>
 	</xsl:variable>
 
 	<xsl:template name="image">
 		<xsl:param name="image" select="image" />
 		<xsl:param name="alt" select="alt" />
-		<xsl:param name="sizes" select="exsl:node-set($default-image-sizes)/sizes" />
+		<xsl:param name="custom-sizes" />
+		<xsl:param name="sizes-node">
+			<xsl:choose>
+				<xsl:when test="util:count($custom-sizes) &gt; 0">
+					<sizes>
+						<xsl:copy-of select="$custom-sizes" />
+					</sizes>
+				</xsl:when>
+				<xsl:otherwise>
+					<xsl:copy-of select="$default-image-sizes" />
+				</xsl:otherwise>
+			</xsl:choose>
+		</xsl:param>
+		<xsl:param name="sizes" select="exsl:node-set($sizes-node)/sizes" />
 		<xsl:param name="use-sizes" select="$image/@type != 'image/gif' and $image/@type != 'image/svg+xml' and $image/@type != 'image/svg' and $image/@type != 'image/tiff' and $image/@type != 'text/plain'"/>
-		<xsl:param name="ext-attr" />
+		<xsl:param name="valid-sizes" select="$sizes/size[@width &lt; $image/meta/@width]" />
+		<xsl:param name="srcset">
+			<xsl:if test="$use-sizes">
+				<xsl:apply-templates select="$valid-sizes" mode="image-source">
+					<xsl:with-param name="image" select="$image" />
+				</xsl:apply-templates>
+			</xsl:if>
+		</xsl:param>
+		<xsl:param name="media-queries">
+			<xsl:if test="$use-sizes">
+				<xsl:apply-templates select="$valid-sizes" mode="image-media-query">
+					<xsl:with-param name="image" select="$image" />
+				</xsl:apply-templates>
+			</xsl:if>
+		</xsl:param>
 
-		<xsl:variable name="srcset">
-			<xsl:apply-templates select="$sizes/size" mode="image-source">
-				<xsl:with-param name="image" select="$image" />
-			</xsl:apply-templates>
-		</xsl:variable>
+		<xsl:param name="ext-attr" />
 
 		<xsl:variable name="attr">
 			<add class="block width-full" />
@@ -35,6 +60,9 @@
 			<set alt="{$alt}" />
 			<xsl:if test="string-length($srcset) != 0">
 				<set srcset="{$srcset}" />
+			</xsl:if>
+			<xsl:if test="string-length($media-queries) != 0">
+				<set sizes="{$media-queries}" />
 			</xsl:if>
 			<set loading="lazy" />
 			<xsl:copy-of select="$ext-attr" />
@@ -47,6 +75,40 @@
 		</xsl:call-template>
 	</xsl:template>
 
+	<xsl:template name="image-width">
+		<xsl:param name="image" />
+		<xsl:param name="size" />
+
+		<xsl:choose>
+			<xsl:when test="number($size/@width) &gt; 0">
+				<xsl:value-of select="$size/@width" />
+			</xsl:when>
+			<xsl:otherwise>
+				<xsl:value-of select="round((number($image/meta/@width) div number($image/meta/@height)) * number($size/@height))" />
+			</xsl:otherwise>
+		</xsl:choose>
+	</xsl:template> <!-- image-width -->
+
+	<xsl:template match="size" mode="image-media-query">
+		<xsl:param name="size" select="." />
+		<xsl:param name="image" />
+		<xsl:param name="width">
+			<xsl:call-template name="image-width">
+				<xsl:with-param name="size" select="$size" />
+				<xsl:with-param name="image" select="$image"/>
+			</xsl:call-template>
+		</xsl:param>
+
+		<xsl:value-of select="$size/@media" />
+		<xsl:text> </xsl:text>
+		<xsl:value-of select="$width" />
+		<xsl:text>px</xsl:text>
+		<xsl:if test="position() != last()">, </xsl:if>
+		<xsl:if test="position() = last()">
+			<xsl:text>, 100vw</xsl:text>
+		</xsl:if>
+	</xsl:template> <!-- image-media-query -->
+
 	<xsl:template match="size" mode="image-source">
 		<xsl:param name="size" select="." />
 		<xsl:param name="image" />
@@ -56,10 +118,16 @@
 				<xsl:with-param name="image" select="$image" />
 			</xsl:call-template>
 		</xsl:param>
+		<xsl:param name="width">
+			<xsl:call-template name="image-width">
+				<xsl:with-param name="size" select="$size" />
+				<xsl:with-param name="image" select="$image"/>
+			</xsl:call-template>
+		</xsl:param>
 
 		<xsl:value-of select="$src" />
 		<xsl:text> </xsl:text>
-		<xsl:value-of select="$size/@width" />
+		<xsl:value-of select="$width" />
 		<xsl:text>w</xsl:text>
 		<xsl:if test="postion() != last()">, </xsl:if>
 	</xsl:template> <!-- image-source -->

--- a/workspace/utilities/lib/image.xsl
+++ b/workspace/utilities/lib/image.xsl
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" 
+								xmlns:exsl="http://exslt.org/common" 
+								extension-element-prefixes="exsl">
+
+	<xsl:variable name="default-image-sizes">
+		<sizes>
+			<size height="0" width="430" />
+			<size height="0" width="620" />
+			<size height="0" width="800" />
+			<size height="0" width="960" />
+			<size height="0" width="1100" />
+			<size height="0" width="1260" />
+			<size height="0" width="1400" />
+			<size height="0" width="2000" />
+		</sizes>
+	</xsl:variable>
+
+	<xsl:template name="image">
+		<xsl:param name="image" select="image" />
+		<xsl:param name="alt" select="alt" />
+		<xsl:param name="sizes" select="exsl:node-set($default-image-sizes)/sizes" />
+		<xsl:param name="use-sizes" select="$image/@type != 'image/gif' and $image/@type != 'image/svg+xml' and $image/@type != 'image/svg' and $image/@type != 'image/tiff' and $image/@type != 'text/plain'"/>
+		<xsl:param name="ext-attr" />
+
+		<xsl:variable name="srcset">
+			<xsl:apply-templates select="$sizes/size" mode="image-source">
+				<xsl:with-param name="image" select="$image" />
+			</xsl:apply-templates>
+		</xsl:variable>
+
+		<xsl:variable name="attr">
+			<add class="block width-full" />
+			<set src="/workspace{$image/@path}/{$image/filename}" />
+			<set alt="{$alt}" />
+			<xsl:if test="string-length($srcset) != 0">
+				<set srcset="{$srcset}" />
+			</xsl:if>
+			<set loading="lazy" />
+			<xsl:copy-of select="$ext-attr" />
+			<add dev-component="image" />
+		</xsl:variable>
+
+		<xsl:call-template name="element">
+			<xsl:with-param name="attr" select="$attr-img" />
+			<xsl:with-param name="element" select="'img'" />
+		</xsl:call-template>
+	</xsl:template>
+
+	<xsl:template match="size" mode="image-source">
+		<xsl:param name="size" select="." />
+		<xsl:param name="image" />
+		<xsl:param name="src">
+			<xsl:call-template name="image-src">
+				<xsl:with-param name="size" select="$size" />
+				<xsl:with-param name="image" select="$image" />
+			</xsl:call-template>
+		</xsl:param>
+
+		<xsl:value-of select="$src" />
+		<xsl:text> </xsl:text>
+		<xsl:value-of select="$size/@width" />
+		<xsl:text>w</xsl:text>
+		<xsl:if test="postion() != last()">, </xsl:if>
+	</xsl:template> <!-- image-source -->
+
+	<xsl:template name="image-src">
+		<xsl:param name="image" />
+		<xsl:param name="size" />
+		<xsl:text>/image/1/</xsl:text>
+		<xsl:value-of select="$size/@request-height" />
+		<xsl:text>/</xsl:text>
+		<xsl:value-of select="$size/@request-width" />
+		<xsl:value-of select="$image/@path" />
+		<xsl:text>/</xsl:text>
+		<xsl:value-of select="$image/filename" />
+	</xsl:template> <!-- image-src -->
+
+</xsl:stylesheet>

--- a/workspace/utilities/lib/image.xsl
+++ b/workspace/utilities/lib/image.xsl
@@ -68,9 +68,9 @@
 		<xsl:param name="image" />
 		<xsl:param name="size" />
 		<xsl:text>/image/1/</xsl:text>
-		<xsl:value-of select="$size/@request-height" />
+		<xsl:value-of select="$size/@width" />
 		<xsl:text>/</xsl:text>
-		<xsl:value-of select="$size/@request-width" />
+		<xsl:value-of select="$size/@height" />
 		<xsl:value-of select="$image/@path" />
 		<xsl:text>/</xsl:text>
 		<xsl:value-of select="$image/filename" />

--- a/workspace/utilities/lib/picture.xsl
+++ b/workspace/utilities/lib/picture.xsl
@@ -3,93 +3,26 @@
 								xmlns:exsl="http://exslt.org/common" 
 								extension-element-prefixes="exsl">
 
-	<xsl:variable name="default-image-sizes">
-		<sizes>
-			<size request-height="0" request-width="430" media="(max-width: 430px)" />
-			<size request-height="0" request-width="620" media="(max-width: 620px)" />
-			<size request-height="0" request-width="800" media="(max-width: 800px)" />
-			<size request-height="0" request-width="960" media="(max-width: 960px)" />
-			<size request-height="0" request-width="1100" media="(max-width: 1100px)" />
-			<size request-height="0" request-width="1260" media="(max-width: 1260px)" />
-			<size request-height="0" request-width="1400" media="(max-width: 1400px)" />
-			<size request-height="0" request-width="2000" media="(max-width: 2000px)" />
-		</sizes>
-	</xsl:variable>
-
 	<xsl:template name="picture">
 		<xsl:param name="image" select="image" />
 		<xsl:param name="alt" select="alt" />
-		<xsl:param name="sizes" select="exsl:node-set($default-image-sizes)/sizes" />
-		<xsl:param name="use-sizes" select="$image/@type != 'image/gif' and $image/@type != 'image/svg+xml' and $image/@type != 'image/svg' and $image/@type != 'image/tiff' and $image/@type != 'text/plain'"/>
 		<xsl:param name="ext-attr" />
 		<xsl:param name="ext-attr-image" />
 
 		<xsl:variable name="attr">
 			<xsl:copy-of select="$ext-attr" />
-			<add dev-component="picture" />
-		</xsl:variable>
-
-		<xsl:variable name="attr-img">
-			<add class="block width-full" />
-			<set src="/workspace{$image/@path}/{$image/filename}" />
-			<set alt="{$alt}" />
-			<set loading="lazy" />
 			<xsl:copy-of select="$ext-attr-image" />
-			<add dev-element="img" />
 		</xsl:variable>
 
-		<xsl:call-template name="element">
-			<xsl:with-param name="attr" select="$attr" />
-			<xsl:with-param name="element" select="'picture'" />
-			<xsl:with-param name="content">
-
-				<xsl:if test="$use-sizes">
-					<xsl:apply-templates select="$sizes/size" mode="picture-source">
-						<xsl:with-param name="image" select="$image" />
-					</xsl:apply-templates>
-				</xsl:if>
-
-				<xsl:call-template name="element">
-					<xsl:with-param name="attr" select="$attr-img" />
-					<xsl:with-param name="element" select="'img'" />
-				</xsl:call-template>
-			</xsl:with-param>
+		<xsl:call-template name="image">
+			<xsl:with-param name="image" select="$image" />
+			<xsl:with-param name="alt" select="$alt" />
+			<xsl:with-param name="ext-attr" select="$attr" />
 		</xsl:call-template>
+
+		<xsl:if test="$debug">
+			<pre>The XSLT template picture has been deprecated. Please use the XSLT template image.</pre>
+		</xsl:if>
 	</xsl:template>
-
-	<xsl:template match="size" mode="picture-source">
-		<xsl:param name="size" select="." />
-		<xsl:param name="image" />
-		<xsl:param name="srcset">
-			<xsl:call-template name="picture-src">
-				<xsl:with-param name="size" select="$size" />
-				<xsl:with-param name="image" select="$image" />
-			</xsl:call-template>
-		</xsl:param>
-
-		<xsl:variable name="attr">
-			<set srcset="{$srcset}" />
-			<set type="{$image/@type}" />
-			<set media="{$size/@media}" />
-			<add dev-element="picture-source" />
-		</xsl:variable>
-
-		<xsl:call-template name="element">
-			<xsl:with-param name="attr" select="$attr" />
-			<xsl:with-param name="element" select="'source'" />
-		</xsl:call-template>
-	</xsl:template> <!-- picture-source -->
-
-	<xsl:template name="picture-src">
-		<xsl:param name="image" />
-		<xsl:param name="size" />
-		<xsl:text>/image/1/</xsl:text>
-		<xsl:value-of select="$size/@request-height" />
-		<xsl:text>/</xsl:text>
-		<xsl:value-of select="$size/@request-width" />
-		<xsl:value-of select="$image/@path" />
-		<xsl:text>/</xsl:text>
-		<xsl:value-of select="$image/filename" />
-	</xsl:template> <!-- picture-src -->
 
 </xsl:stylesheet>

--- a/workspace/utilities/lib/util-ficelle.xsl
+++ b/workspace/utilities/lib/util-ficelle.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 	
-	<xsl:template name="picture-src">
+	<xsl:template name="image-src">
 		<xsl:param name="image" />
 		<xsl:param name="size" />
 

--- a/workspace/utilities/master/master.xsl
+++ b/workspace/utilities/master/master.xsl
@@ -43,6 +43,7 @@
 
 	<!-- Media -->
 	<xsl:import href="../lib/picture.xsl" />
+	<xsl:import href="../lib/image.xsl" />
 	<xsl:import href="../lib/video.xsl" />
 
 	<!-- LIB COMPOSITION -->


### PR DESCRIPTION
Hello 👋 

This proposal is to replace our good old picture template. The only thing that will change for the HTML rendering is the elimination of the node picture and all it's `<source />` tags. The template will create an srcset that will be applied direclty on the `<img />` tag instead. So it's gonna make a less messy HTML file to downlaod and probably help the engines a bit with the HTML parsing.

I also added a "polyfill" for picture. It will use the template image since the signature is very similar and will output a depreciation msg if in debug mode.