### PR TITLE
Ficelle template Update

### DIFF
--- a/workspace/utilities/lib/util-ficelle.xsl
+++ b/workspace/utilities/lib/util-ficelle.xsl
@@ -1,26 +1,33 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	
-	<xsl:template name="image-src">
+<xsl:stylesheet version="1.0"
+	xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+	xmlns:str="http://exslt.org/strings"
+	exclude-result-prefixes="str">
+
+	<xsl:template name="picture-src">
 		<xsl:param name="image" />
 		<xsl:param name="size" />
-		<xsl:param name="quality" select="80" />
+		<xsl:param name="quality" select="'80'"/>
+
+		<xsl:variable name="computed-src">
+			<xsl:value-of select="$root" />
+			<xsl:text>/workspace</xsl:text>
+			<xsl:value-of select="$image/@path" />
+			<xsl:text>/</xsl:text>
+			<xsl:value-of select="$image/filename" />
+		</xsl:variable>
 
 		<xsl:text>https://ficelle.app/v1/?src=</xsl:text>
-		<xsl:value-of select="$root" />
-		<xsl:text>/workspace</xsl:text>
-		<xsl:value-of select="$image/@path" />
-		<xsl:text>/</xsl:text>
-		<xsl:value-of select="$image/filename" />
-		<xsl:text>&amp;forceSVG=true</xsl:text>
-		<xsl:if test="number($size/@request-width) &gt; 1">
-			<xsl:text>&amp;width=</xsl:text><xsl:value-of select="$size/@request-width" />
+		<xsl:value-of select="str:encode-uri($computed-src, true())" />
+		<xsl:if test="number($size/@width) &gt; 1">
+			<xsl:text>&amp;width=</xsl:text><xsl:value-of select="$size/@width" />
 		</xsl:if>
 		<xsl:if test="number($size/@request-height) &gt; 1">
 			<xsl:text>&amp;height=</xsl:text><xsl:value-of select="$size/@request-height" />
 		</xsl:if>
-		<xsl:text>&amp;quality=</xsl:text>
-		<xsl:value-of select="$quality" />
+		<xsl:if test="number($quality) &gt; 1">
+			<xsl:text>&amp;quality=</xsl:text><xsl:value-of select="$quality" />
+		</xsl:if>
 	</xsl:template>
 
 </xsl:stylesheet>

--- a/workspace/utilities/site-imports.xsl
+++ b/workspace/utilities/site-imports.xsl
@@ -56,7 +56,7 @@
 	<xsl:import href="lib/util-auto-handle.xsl" />
 	<xsl:import href="lib/util-rewrite-markdown.xsl" />
 	<xsl:import href="lib/util-transition-scroll-attr.xsl" />
-	<xsl:import href="lib/util-ficelle.xsl" />
+	<!-- <xsl:import href="lib/util-ficelle.xsl" /> -->
 	<xsl:import href="lib/util-count.xsl" />
 	<xsl:import href="com/util-auto-url.xsl" />
 	<xsl:import href="com/util-module-interval-attr.xsl" />


### PR DESCRIPTION
* url encode the src
* removed unnesessary forceSVG key with Ficelle >= 1.11.x
* Default quality attribute since the automatic quality setting is not stable enough for clients.
* Do not import Ficelle by default in projects